### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,8 +9,8 @@
 SD	KEYWORD1	SD
 File	KEYWORD1	SD
 SDFile	KEYWORD1	SD
-Sd2Card	KEYWORD1	Sd2Card
-SdFatFs	KEYWORD1	SdFatFs
+Sd2Card	KEYWORD1
+SdFatFs	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format