### PR TITLE
Add several update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# STM32SD
-
-## SD library for Arduino
+# STM32 SD library for Arduino
 
 With an STM32 board with SD card slot availability, this library enables
 reading and writing on SD card using SD card slot of a STM32 board (NUCLEO, DISCOVERY, ...).
@@ -10,9 +8,16 @@ This library follow Arduino API.
 For more information about it, please visit:
 http://www.arduino.cc/en/Reference/SD
 
-## Note
+## Dependency
 
-The library is based on FatFs, a generic FAT file system module for small embedded systems.  
+This library is based on FatFs, a generic FAT file system module for small embedded systems.  
 [http://elm-chan.org/fsw/ff](http://elm-chan.org/fsw/ff/00index_e.html)
 
 The FatFs has been ported as Arduino library [here](https://github.com/stm32duino/FatFs). The STM32SD library depends on it.
+
+## Configuration
+The FatFs has several user defined options, which is specified from within the `ffconf.h` file.
+
+This library provides a default user defined options file named `ffconf_default.h`.
+
+User can provide his own defined options by adding his configuration in a file named `ffconf_custom.h` at sketch level or in variant folder.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,20 @@ http://www.arduino.cc/en/Reference/SD
 This library is based on FatFs, a generic FAT file system module for small embedded systems.  
 [http://elm-chan.org/fsw/ff](http://elm-chan.org/fsw/ff/00index_e.html)
 
-The FatFs has been ported as Arduino library [here](https://github.com/stm32duino/FatFs). The STM32SD library depends on it.
+The FatFs has been ported as Arduino library [here](https://github.com/stm32duino/FatFs).
+The STM32SD library depends on it.
 
 ## Configuration
+
+### FatFs
 The FatFs has several user defined options, which is specified from within the `ffconf.h` file.
 
 This library provides a default user defined options file named `ffconf_default.h`.
 
-User can provide his own defined options by adding his configuration in a file named `ffconf_custom.h` at sketch level or in variant folder.
+User can provide his own defined options by adding his configuration in a file named
+`ffconf_custom.h` at sketch level or in variant folder.
+
+### SD detect and timeout
+* `SD_DETECT_PIN` pin number can be defined in `variant.h` or using `build_opt.h`.
+
+* `SD_DATATIMEOUT` constant for Read/Write block could be redefined in `variant.h` or using `build_opt.h`

--- a/examples/CardInfo/CardInfo.ino
+++ b/examples/CardInfo/CardInfo.ino
@@ -11,6 +11,12 @@
 // include the SD library:
 #include <STM32SD.h>
 
+// If SD card slot has no detect pin then define it as SD_DETECT_NONE
+// to ignore it. One other option is to call 'card.init()' without parameter.
+#ifndef SD_DETECT_PIN
+#define SD_DETECT_PIN SD_DETECT_NONE
+#endif
+
 Sd2Card card;
 SdFatFs fatFs;
 

--- a/examples/Datalogger/Datalogger.ino
+++ b/examples/Datalogger/Datalogger.ino
@@ -12,6 +12,12 @@
 
 #include <STM32SD.h>
 
+// If SD card slot has no detect pin then define it as SD_DETECT_NONE
+// to ignore it. One other option is to call 'SD.begin()' without parameter.
+#ifndef SD_DETECT_PIN
+#define SD_DETECT_PIN SD_DETECT_NONE
+#endif
+
 uint32_t A[] = { A0, A1, A2};
 
 void setup()

--- a/examples/DumpFile/DumpFile.ino
+++ b/examples/DumpFile/DumpFile.ino
@@ -13,6 +13,12 @@
 
 #include <STM32SD.h>
 
+// If SD card slot has no detect pin then define it as SD_DETECT_NONE
+// to ignore it. One other option is to call 'SD.begin()' without parameter.
+#ifndef SD_DETECT_PIN
+#define SD_DETECT_PIN SD_DETECT_NONE
+#endif
+
 void setup()
 {
   // Open serial communications and wait for port to open:

--- a/examples/Files/Files.ino
+++ b/examples/Files/Files.ino
@@ -10,6 +10,12 @@
  */
 #include <STM32SD.h>
 
+// If SD card slot has no detect pin then define it as SD_DETECT_NONE
+// to ignore it. One other option is to call 'SD.begin()' without parameter.
+#ifndef SD_DETECT_PIN
+#define SD_DETECT_PIN SD_DETECT_NONE
+#endif
+
 File myFile;
 
 void setup()

--- a/examples/Full/Full.ino
+++ b/examples/Full/Full.ino
@@ -1,5 +1,11 @@
 #include <STM32SD.h>
 
+// If SD card slot has no detect pin then define it as SD_DETECT_NONE
+// to ignore it. One other option is to call 'SD.begin()' without parameter.
+#ifndef SD_DETECT_PIN
+#define SD_DETECT_PIN SD_DETECT_NONE
+#endif
+
 #define COUNTOF(__BUFFER__)   (sizeof(__BUFFER__) / sizeof(*(__BUFFER__)))
 #define BUFFERSIZE                       (COUNTOF(wtext) -1)
 

--- a/examples/ReadWrite/ReadWrite.ino
+++ b/examples/ReadWrite/ReadWrite.ino
@@ -11,6 +11,12 @@
 
 #include <STM32SD.h>
 
+// If SD card slot has no detect pin then define it as SD_DETECT_NONE
+// to ignore it. One other option is to call 'SD.begin()' without parameter.
+#ifndef SD_DETECT_PIN
+#define SD_DETECT_PIN SD_DETECT_NONE
+#endif
+
 File myFile;
 
 void setup()

--- a/examples/listfiles/listfiles.ino
+++ b/examples/listfiles/listfiles.ino
@@ -12,6 +12,12 @@
  */
 #include <STM32SD.h>
 
+// If SD card slot has no detect pin then define it as SD_DETECT_NONE
+// to ignore it. One other option is to call 'SD.begin()' without parameter.
+#ifndef SD_DETECT_PIN
+#define SD_DETECT_PIN SD_DETECT_NONE
+#endif
+
 File root;
 
 void setup()

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=STM32duino STM32SD
-version=1.0.1
+version=1.1.0
 author=Several
 maintainer=stm32duino
 sentence=Enables reading and writing on SD card using SD card slot of the STM32 Board.

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -59,25 +59,7 @@ SDClass SD;
 
 /**
   * @brief  Link SD, register the file system object to the FatFs mode and configure
-  *         relatives SD IOs except SD Detect Pin
-  * @param  None
-  * @retval TRUE or FALSE
-  */
-uint8_t SDClass::begin()
-{
-	/*##-1- Initializes SD IOs #############################################*/
-	if (_card.init()) {
-		return _fatFs.init();
-    }
-    else
-    {
-	  return FALSE;
-    }
-}
-
-/**
-  * @brief  Link SD, register the file system object to the FatFs mode and configure
-  *         relatives SD IOs including SD Detect Pin
+  *         relatives SD IOs including SD Detect Pin if any
   * @param  None
   * @retval TRUE or FALSE
   */
@@ -87,10 +69,7 @@ uint8_t SDClass::begin(uint32_t cspin)
 	if (_card.init(cspin)) {
 		return _fatFs.init();
     }
-    else
-    {
-	  return FALSE;
-    }
+    return FALSE;
 }
 
 /**

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -81,7 +81,7 @@ uint8_t SDClass::begin()
   * @param  None
   * @retval TRUE or FALSE
   */
-uint8_t SDClass::begin(uint8_t cspin)
+uint8_t SDClass::begin(uint32_t cspin)
 {
 	/*##-1- Initializes SD IOs #############################################*/
 	if (_card.init(cspin)) {

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -593,11 +593,9 @@ uint8_t File::isDirectory()
 		{
 			return TRUE;
 		}
-		else
-		{
-			return FALSE;
-		}
 	}
+	// Assume not a directory
+	return FALSE;
 }
 
 File File::openNextFile(uint8_t mode)

--- a/src/STM32SD.h
+++ b/src/STM32SD.h
@@ -79,7 +79,7 @@ public:
 
   /* Initialize the SD peripheral */
   uint8_t begin();
-  uint8_t begin(uint8_t cspin);
+  uint8_t begin(uint32_t cspin);
   static File open(const char *filepath, uint8_t mode);
   static File open(const char *filepath);
   static uint8_t exists(const char *filepath);

--- a/src/STM32SD.h
+++ b/src/STM32SD.h
@@ -78,8 +78,7 @@ class SDClass {
 public:
 
   /* Initialize the SD peripheral */
-  uint8_t begin();
-  uint8_t begin(uint32_t cspin);
+  uint8_t begin(uint32_t cspin = SD_DETECT_NONE);
   static File open(const char *filepath, uint8_t mode);
   static File open(const char *filepath);
   static uint8_t exists(const char *filepath);

--- a/src/Sd2Card.cpp
+++ b/src/Sd2Card.cpp
@@ -37,22 +37,18 @@
 #include <Arduino.h>
 #include "Sd2Card.h"
 
-uint8_t Sd2Card::init(void) {
+uint8_t Sd2Card::init(uint32_t cspin) {
+	if(cspin != SD_DETECT_NONE) {
+		PinName p = digitalPinToPinName(cspin);
+		if((p == NC) ||\
+		   BSP_SD_CSSet(set_GPIO_Port_Clock(STM_PORT(p)),
+						 STM_GPIO_PIN(p)) != MSD_OK) {
+			return FALSE;
+		}
+	}
 	if (BSP_SD_Init() == MSD_OK) {
 		BSP_SD_GetCardInfo(&_SdCardInfo);
 		return TRUE;
-	} else {
-		return FALSE;
-	}
-}
-
-uint8_t Sd2Card::init(uint32_t cspin) {
-	PinName p = digitalPinToPinName(cspin);
-	if(p != NC) {
-		if (BSP_SD_CSInit(set_GPIO_Port_Clock(STM_PORT(p)), STM_GPIO_PIN(p)) == MSD_OK) {
-			BSP_SD_GetCardInfo(&_SdCardInfo);
-			return TRUE;
-		}
 	}
 	return FALSE;
 }

--- a/src/Sd2Card.cpp
+++ b/src/Sd2Card.cpp
@@ -46,13 +46,15 @@ uint8_t Sd2Card::init(void) {
 	}
 }
 
-uint8_t Sd2Card::init(uint8_t cspin) {
-	if (BSP_SD_CSInit() == MSD_OK) {
-		BSP_SD_GetCardInfo(&_SdCardInfo);
-		return TRUE;
-	} else {
-		return FALSE;
+uint8_t Sd2Card::init(uint32_t cspin) {
+	PinName p = digitalPinToPinName(cspin);
+	if(p != NC) {
+		if (BSP_SD_CSInit(set_GPIO_Port_Clock(STM_PORT(p)), STM_GPIO_PIN(p)) == MSD_OK) {
+			BSP_SD_GetCardInfo(&_SdCardInfo);
+			return TRUE;
+		}
 	}
+	return FALSE;
 }
 
 uint8_t Sd2Card::type(void) const {

--- a/src/Sd2Card.h
+++ b/src/Sd2Card.h
@@ -56,8 +56,7 @@
 class Sd2Card {
  public:
 
-  uint8_t init(void);
-  uint8_t init(uint32_t cspin);
+  uint8_t init(uint32_t cspin = SD_DETECT_NONE);
 
   /** Return the card type: SD V1, SD V2 or SDHC */
   uint8_t type(void) const;

--- a/src/Sd2Card.h
+++ b/src/Sd2Card.h
@@ -57,7 +57,7 @@ class Sd2Card {
  public:
 
   uint8_t init(void);
-  uint8_t init(uint8_t cspin);
+  uint8_t init(uint32_t cspin);
 
   /** Return the card type: SD V1, SD V2 or SDHC */
   uint8_t type(void) const;

--- a/src/bsp_sd.c
+++ b/src/bsp_sd.c
@@ -81,8 +81,42 @@
 /* Includes ------------------------------------------------------------------*/
 #include "bsp_sd.h"
 
+#ifdef SDMMC1
+/* Definition for BSP SD */
+#define SD_INSTANCE            SDMMC1
+#define SD_CLK_ENABLE          __HAL_RCC_SDMMC1_CLK_ENABLE
+#define SD_CLK_DISABLE         __HAL_RCC_SDMMC1_CLK_DISABLE
+#define SD_CLK_EDGE            SDMMC_CLOCK_EDGE_RISING
+#define SD_CLK_BYPASS          SDMMC_CLOCK_BYPASS_DISABLE
+#define SD_CLK_PWR_SAVE        SDMMC_CLOCK_POWER_SAVE_DISABLE
+#define SD_BUS_WIDE_1B         SDMMC_BUS_WIDE_1B
+#define SD_BUS_WIDE_4B         SDMMC_BUS_WIDE_4B
+#define SD_HW_FLOW_CTRL        SDMMC_HARDWARE_FLOW_CONTROL_DISABLE
+#define SD_CLK_DIV             SDMMC_TRANSFER_CLK_DIV
+/* Definition for MSP SD */
+#define SD_AF                  GPIO_AF12_SDMMC1
+#elif defined(SDIO)
+/* Definition for BSP SD */
+#define SD_INSTANCE            SDIO
+#define SD_CLK_ENABLE          __HAL_RCC_SDIO_CLK_ENABLE
+#define SD_CLK_DISABLE         __HAL_RCC_SDIO_CLK_DISABLE
+#define SD_CLK_EDGE            SDIO_CLOCK_EDGE_RISING
+#define SD_CLK_BYPASS          SDIO_CLOCK_BYPASS_DISABLE
+#define SD_CLK_PWR_SAVE        SDIO_CLOCK_POWER_SAVE_DISABLE
+#define SD_BUS_WIDE_1B         SDIO_BUS_WIDE_1B
+#define SD_BUS_WIDE_4B         SDIO_BUS_WIDE_4B
+#define SD_HW_FLOW_CTRL        SDIO_HARDWARE_FLOW_CONTROL_DISABLE
+#define SD_CLK_DIV             SDIO_TRANSFER_CLK_DIV
+/* Definition for MSP SD */
+#define SD_AF                  GPIO_AF12_SDIO
+#else
+#error "Unknown SD_INSTANCE"
+#endif
+
 /* BSP SD Private Variables */
 static SD_HandleTypeDef uSdHandle;
+static uint32_t SD_detect_gpio_pin = GPIO_PIN_All;
+static GPIO_TypeDef *SD_detect_gpio_port = GPIOA;
 #if defined (STM32F4xx) || defined(STM32F7xx) || defined(STM32L4xx)
 #define SD_OK                         HAL_OK
 #define SD_TRANSFER_OK                ((uint8_t)0x00)
@@ -145,10 +179,11 @@ uint8_t BSP_SD_Init(void)
   * @brief  Initializes the SD card device with CS initialization.
   * @retval SD status
   */
-uint8_t BSP_SD_CSInit(void)
+uint8_t BSP_SD_CSInit(GPIO_TypeDef *csport, uint32_t cspin)
 {
   uint8_t sd_state = MSD_OK;
-
+  SD_detect_gpio_pin = cspin;
+  SD_detect_gpio_port = csport;
   /* PLLSAI is dedicated to LCD periph. Do not use it to get 48MHz*/
 
   /* uSD device interface configuration */
@@ -226,20 +261,61 @@ uint8_t BSP_SD_DeInit(void)
   */
 uint8_t BSP_SD_ITConfig(void)
 {
+  uint8_t sd_state = MSD_OK;
   GPIO_InitTypeDef gpio_init_structure;
+  IRQn_Type sd_detect_EXTI_IRQn = EXTI0_IRQn;
 
   /* Configure Interrupt mode for SD detection pin */
-  gpio_init_structure.Pin = SD_DETECT_PIN;
+  gpio_init_structure.Pin = SD_detect_gpio_pin;
   gpio_init_structure.Pull = GPIO_PULLUP;
   gpio_init_structure.Speed = GPIO_SPEED_FAST;
   gpio_init_structure.Mode = GPIO_MODE_IT_RISING_FALLING;
-  HAL_GPIO_Init(SD_DETECT_GPIO_PORT, &gpio_init_structure);
+  HAL_GPIO_Init(SD_detect_gpio_port, &gpio_init_structure);
 
-  /* Enable and set SD detect EXTI Interrupt to the lowest priority */
-  HAL_NVIC_SetPriority((IRQn_Type)(SD_DETECT_EXTI_IRQn), 0x0F, 0x00);
-  HAL_NVIC_EnableIRQ((IRQn_Type)(SD_DETECT_EXTI_IRQn));
-
-  return MSD_OK;
+  if(SD_detect_gpio_pin == GPIO_PIN_0) {
+      sd_detect_EXTI_IRQn = EXTI0_IRQn;
+  } else {
+    if(SD_detect_gpio_pin == GPIO_PIN_1) {
+      sd_detect_EXTI_IRQn = EXTI1_IRQn;
+    } else {
+      if(SD_detect_gpio_pin == GPIO_PIN_2) {
+        sd_detect_EXTI_IRQn = EXTI2_IRQn;
+      } else {
+        if(SD_detect_gpio_pin == GPIO_PIN_3) {
+          sd_detect_EXTI_IRQn = EXTI3_IRQn;
+        } else {
+          if(SD_detect_gpio_pin == GPIO_PIN_4) {
+            sd_detect_EXTI_IRQn = EXTI4_IRQn;
+          } else {
+            if((SD_detect_gpio_pin == GPIO_PIN_5) ||\
+               (SD_detect_gpio_pin == GPIO_PIN_6) ||\
+               (SD_detect_gpio_pin == GPIO_PIN_7) ||\
+               (SD_detect_gpio_pin == GPIO_PIN_8) ||\
+               (SD_detect_gpio_pin == GPIO_PIN_9)) {
+              sd_detect_EXTI_IRQn = EXTI9_5_IRQn;
+            } else {
+              if((SD_detect_gpio_pin == GPIO_PIN_10) ||\
+                 (SD_detect_gpio_pin == GPIO_PIN_11) ||\
+                 (SD_detect_gpio_pin == GPIO_PIN_12) ||\
+                 (SD_detect_gpio_pin == GPIO_PIN_13) ||\
+                 (SD_detect_gpio_pin == GPIO_PIN_14) ||\
+                 (SD_detect_gpio_pin == GPIO_PIN_15)) {
+                sd_detect_EXTI_IRQn = EXTI15_10_IRQn;
+              } else {
+                sd_state = MSD_ERROR;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if(sd_state == MSD_OK) {
+    /* Enable and set SD detect EXTI Interrupt to the lowest priority */
+    HAL_NVIC_SetPriority(sd_detect_EXTI_IRQn, 0x0F, 0x00);
+    HAL_NVIC_EnableIRQ(sd_detect_EXTI_IRQn);
+  }
+  return sd_state;
 }
 
 /**
@@ -251,7 +327,7 @@ uint8_t BSP_SD_IsDetected(void)
   uint8_t  status = SD_PRESENT;
 
   /* Check SD card detect pin */
-  if (HAL_GPIO_ReadPin(SD_DETECT_GPIO_PORT, SD_DETECT_PIN) == GPIO_PIN_SET)
+  if (HAL_GPIO_ReadPin(SD_detect_gpio_port, SD_detect_gpio_pin) == GPIO_PIN_SET)
   {
     status = SD_NOT_PRESENT;
   }
@@ -363,14 +439,12 @@ __weak void BSP_SD_Detect_MspInit(SD_HandleTypeDef *hsd, void *Params)
   UNUSED(Params);
   GPIO_InitTypeDef  gpio_init_structure;
 
-  SD_DETECT_GPIO_CLK_ENABLE();
-
   /* GPIO configuration in input for uSD_Detect signal */
-  gpio_init_structure.Pin       = SD_DETECT_PIN;
+  gpio_init_structure.Pin       = SD_detect_gpio_pin;
   gpio_init_structure.Mode      = GPIO_MODE_INPUT;
   gpio_init_structure.Pull      = GPIO_PULLUP;
   gpio_init_structure.Speed     = GPIO_SPEED_HIGH;
-  HAL_GPIO_Init(SD_DETECT_GPIO_PORT, &gpio_init_structure);
+  HAL_GPIO_Init(SD_detect_gpio_port, &gpio_init_structure);
 }
 
 /**
@@ -389,7 +463,7 @@ __weak void BSP_SD_MspDeInit(SD_HandleTypeDef *hsd, void *Params)
        (by surcharging this __weak function) */
 
     /* Disable SDIO clock */
-    __HAL_RCC_SDIO_CLK_DISABLE();
+    SD_CLK_DISABLE();
 
     /* GPOI pins clock and DMA cloks can be shut down in the applic
        by surcgarging this __weak function */

--- a/src/bsp_sd.c
+++ b/src/bsp_sd.c
@@ -269,7 +269,7 @@ uint8_t BSP_SD_IsDetected(void)
   */
 uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumOfBlocks)
 {
-  if(HAL_SD_ReadBlocks(&uSdHandle, pData, ReadAddr, BlockSize, NumOfBlocks) != SD_OK)
+  if(HAL_SD_ReadBlocks(&uSdHandle, (uint8_t *)pData, ReadAddr, BlockSize, NumOfBlocks) != SD_OK)
   {
     return MSD_ERROR;
   }
@@ -289,7 +289,7 @@ uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint64_t ReadAddr, uint32_t BlockSize
   */
 uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumOfBlocks)
 {
-  if(HAL_SD_WriteBlocks(&uSdHandle, pData, WriteAddr, BlockSize, NumOfBlocks) != SD_OK)
+  if(HAL_SD_WriteBlocks(&uSdHandle, (uint8_t *)pData, WriteAddr, BlockSize, NumOfBlocks) != SD_OK)
   {
     return MSD_ERROR;
   }
@@ -324,6 +324,8 @@ uint8_t BSP_SD_Erase(uint64_t StartAddr, uint64_t EndAddr)
   */
 __weak void BSP_SD_MspInit(SD_HandleTypeDef *hsd, void *Params)
 {
+  UNUSED(hsd);
+  UNUSED(Params);
   GPIO_InitTypeDef gpio_init_structure;
 
   /* Enable SDIO clock */
@@ -357,6 +359,8 @@ __weak void BSP_SD_MspInit(SD_HandleTypeDef *hsd, void *Params)
   */
 __weak void BSP_SD_Detect_MspInit(SD_HandleTypeDef *hsd, void *Params)
 {
+  UNUSED(hsd);
+  UNUSED(Params);
   GPIO_InitTypeDef  gpio_init_structure;
 
   SD_DETECT_GPIO_CLK_ENABLE();
@@ -376,6 +380,8 @@ __weak void BSP_SD_Detect_MspInit(SD_HandleTypeDef *hsd, void *Params)
   */
 __weak void BSP_SD_MspDeInit(SD_HandleTypeDef *hsd, void *Params)
 {
+    UNUSED(hsd);
+    UNUSED(Params);
     /* Disable NVIC for SDIO interrupts */
     HAL_NVIC_DisableIRQ(SDIO_IRQn);
 

--- a/src/bsp_sd.h
+++ b/src/bsp_sd.h
@@ -44,7 +44,11 @@
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-#include "sd_conf.h"
+#include "variant.h"
+/* Could be redefined in variant.h or using build_opt.h */
+#ifndef SD_DATATIMEOUT
+#define SD_DATATIMEOUT         100000000U
+#endif
 
 /*SD Card information structure */
 #if defined (STM32F4xx) || defined(STM32F7xx) || defined(STM32L4xx)
@@ -67,7 +71,7 @@
 
 /* SD Exported Functions */
 uint8_t BSP_SD_Init(void);
-uint8_t BSP_SD_CSInit(void);
+uint8_t BSP_SD_CSInit(GPIO_TypeDef *csport, uint32_t cspin);
 uint8_t BSP_SD_DeInit(void);
 uint8_t BSP_SD_ITConfig(void);
 

--- a/src/bsp_sd.h
+++ b/src/bsp_sd.h
@@ -68,10 +68,11 @@
 /* SD Exported Constants */
 #define SD_PRESENT               ((uint8_t)0x01)
 #define SD_NOT_PRESENT           ((uint8_t)0x00)
+#define SD_DETECT_NONE           NUM_DIGITAL_PINS
 
 /* SD Exported Functions */
 uint8_t BSP_SD_Init(void);
-uint8_t BSP_SD_CSInit(GPIO_TypeDef *csport, uint32_t cspin);
+uint8_t BSP_SD_CSSet(GPIO_TypeDef *csport, uint32_t cspin);
 uint8_t BSP_SD_DeInit(void);
 uint8_t BSP_SD_ITConfig(void);
 

--- a/src/ffconf.h
+++ b/src/ffconf.h
@@ -1,0 +1,17 @@
+/*
+ * @file    ffconf.h
+ * @brief   Include header file to match Arduino library format
+ */
+#ifndef _ARDUINO_FFCONF_H
+#define _ARDUINO_FFCONF_H
+
+#include "stm32_def.h"
+#include "bsp_sd.h"
+
+/* FatFs specific configuration options. */
+#if __has_include("ffconf_custom.h")
+#include "ffconf_custom.h"
+#else
+#include "ffconf_default.h"
+#endif
+#endif /* _ARDUINO_FFCONF_H */

--- a/src/ffconf_default.h
+++ b/src/ffconf_default.h
@@ -1,0 +1,242 @@
+/*---------------------------------------------------------------------------/
+/  FatFs - FAT file system module configuration file  R0.11 (C)ChaN,  2015
+/----------------------------------------------------------------------------/
+/
+/ CAUTION! Do not forget to make clean the project after any changes to
+/ the configuration options.
+/
+/----------------------------------------------------------------------------*/
+#ifndef _FFCONF
+#define _FFCONF 32020 /* Revision ID */
+
+/*-----------------------------------------------------------------------------/
+/ Functions and Buffer Configurations
+/-----------------------------------------------------------------------------*/
+
+#define _FS_TINY             0      /* 0:Normal or 1:Tiny */
+/* When _FS_TINY is set to 1, FatFs uses the sector buffer in the file system
+/  object instead of the sector buffer in the individual file object for file
+/  data transfer. This reduces memory consumption 512 bytes each file object. */
+
+
+#define _FS_READONLY         0      /* 0:Read/Write or 1:Read only */
+/* Setting _FS_READONLY to 1 defines read only configuration. This removes
+/  writing functions, f_write, f_sync, f_unlink, f_mkdir, f_chmod, f_rename,
+/  f_truncate and useless f_getfree. */
+
+
+#define _FS_MINIMIZE         0      /* 0 to 3 */
+/* The _FS_MINIMIZE option defines minimization level to remove some functions.
+/
+/   0: Full function.
+/   1: f_stat, f_getfree, f_unlink, f_mkdir, f_chmod, f_truncate, f_utime
+/      and f_rename are removed.
+/   2: f_opendir and f_readdir are removed in addition to 1.
+/   3: f_lseek is removed in addition to 2. */
+
+
+#define _USE_STRFUNC         2      /* 0:Disable or 1-2:Enable */
+/* To enable string functions, set _USE_STRFUNC to 1 or 2. */
+
+
+#define _USE_MKFS            1      /* 0:Disable or 1:Enable */
+/* To enable f_mkfs function, set _USE_MKFS to 1 and set _FS_READONLY to 0 */
+
+
+#define _USE_FASTSEEK        1      /* 0:Disable or 1:Enable */
+/* To enable fast seek feature, set _USE_FASTSEEK to 1. */
+
+
+#define _USE_LABEL           0      /* 0:Disable or 1:Enable */
+/* To enable volume label functions, set _USE_LAVEL to 1 */
+
+
+#define _USE_FORWARD         0      /* 0:Disable or 1:Enable */
+/* To enable f_forward function, set _USE_FORWARD to 1 and set _FS_TINY to 1. */
+
+#define _USE_FIND            0
+/* This option switches filtered directory read feature and related functions,
+/� f_findfirst() and f_findnext(). (0:Disable or 1:Enable) */
+
+
+/* This option is available only for usbh diskio interface and allow to disable
+/  the management of the unaligned buffer.
+/  When STM32 USB OTG HS or FS IP is used with internal DMA enabled, this define
+/  must be set to 0 to align data into 32bits through an internal scratch buffer
+/  before being processed by the DMA . Otherwise (DMA not used), this define must
+/  be set to 1 to avoid Data alignment and improve the performance.
+/  Please note that if _USE_BUFF_WO_ALIGNMENT is set to 1 and an unaligned 32bits
+/  buffer is forwarded to the FatFs Write/Read functions, an error will be returned.
+/  (0: default value or 1: unaligned buffer return an error). */
+
+
+/*-----------------------------------------------------------------------------/
+/ Local and Namespace Configurations
+/-----------------------------------------------------------------------------*/
+
+#define _CODE_PAGE         1252
+/* The _CODE_PAGE specifies the OEM code page to be used on the target system.
+/  Incorrect setting of the code page can cause a file open failure.
+/
+/   932  - Japanese Shift-JIS (DBCS, OEM, Windows)
+/   936  - Simplified Chinese GBK (DBCS, OEM, Windows)
+/   949  - Korean (DBCS, OEM, Windows)
+/   950  - Traditional Chinese Big5 (DBCS, OEM, Windows)
+/   1250 - Central Europe (Windows)
+/   1251 - Cyrillic (Windows)
+/   1252 - Latin 1 (Windows)
+/   1253 - Greek (Windows)
+/   1254 - Turkish (Windows)
+/   1255 - Hebrew (Windows)
+/   1256 - Arabic (Windows)
+/   1257 - Baltic (Windows)
+/   1258 - Vietnam (OEM, Windows)
+/   437  - U.S. (OEM)
+/   720  - Arabic (OEM)
+/   737  - Greek (OEM)
+/   775  - Baltic (OEM)
+/   850  - Multilingual Latin 1 (OEM)
+/   858  - Multilingual Latin 1 + Euro (OEM)
+/   852  - Latin 2 (OEM)
+/   855  - Cyrillic (OEM)
+/   866  - Russian (OEM)
+/   857  - Turkish (OEM)
+/   862  - Hebrew (OEM)
+/   874  - Thai (OEM, Windows)
+/ 1    - ASCII only (Valid for non LFN cfg.)
+*/
+
+
+#define _USE_LFN     1  /* 0 to 3 */
+#define _MAX_LFN     255  /* Maximum LFN length to handle (12 to 255) */
+/* The _USE_LFN option switches the LFN feature.
+/
+/   0: Disable LFN feature. _MAX_LFN has no effect.
+/   1: Enable LFN with static working buffer on the BSS. Always NOT reentrant.
+/   2: Enable LFN with dynamic working buffer on the STACK.
+/   3: Enable LFN with dynamic working buffer on the HEAP.
+/
+/  To enable LFN feature, Unicode handling functions ff_convert() and ff_wtoupper()
+/  function must be added to the project.
+/  The LFN working buffer occupies (_MAX_LFN + 1) * 2 bytes. When use stack for the
+/  working buffer, take care on stack overflow. When use heap memory for the working
+/  buffer, memory management functions, ff_memalloc() and ff_memfree(), must be added
+/  to the project. */
+
+
+#define _LFN_UNICODE    0 /* 0:ANSI/OEM or 1:Unicode */
+/* To switch the character encoding on the FatFs API to Unicode, enable LFN feature
+/  and set _LFN_UNICODE to 1. */
+
+
+#define _STRF_ENCODE    3 /* 0:ANSI/OEM, 1:UTF-16LE, 2:UTF-16BE, 3:UTF-8 */
+/* When Unicode API is enabled, character encoding on the all FatFs API is switched
+/  to Unicode. This option selects the character encoding on the file to be read/written
+/  via string functions, f_gets(), f_putc(), f_puts and f_printf().
+/  This option has no effect when _LFN_UNICODE is 0. */
+
+
+#define _FS_RPATH       0/* 0 to 2 */
+/* The _FS_RPATH option configures relative path feature.
+/
+/   0: Disable relative path feature and remove related functions.
+/   1: Enable relative path. f_chdrive() and f_chdir() function are available.
+/   2: f_getcwd() function is available in addition to 1.
+/
+/  Note that output of the f_readdir() fnction is affected by this option. */
+
+
+/*---------------------------------------------------------------------------/
+/ Drive/Volume Configurations
+/----------------------------------------------------------------------------*/
+
+#define _VOLUMES    1
+/* Number of volumes (logical drives) to be used. */
+
+
+#define _MULTI_PARTITION     0 /* 0:Single partition, 1:Enable multiple partition */
+/* When set to 0, each volume is bound to the same physical drive number and
+/ it can mount only first primaly partition. When it is set to 1, each volume
+/ is tied to the partitions listed in VolToPart[]. */
+
+
+#define _MIN_SS                 512
+#define _MAX_SS                 512
+/* These options configure the range of sector size to be supported. (512, 1024, 2048 or
+/  4096) Always set both 512 for most systems, all memory card and harddisk. But a larger
+/  value may be required for on-board flash memory and some type of optical media.
+/  When _MAX_SS is larger than _MIN_SS, FatFs is configured to variable sector size and
+/  GET_SECTOR_SIZE command must be implemented to the disk_ioctl() function. */
+
+
+#define _USE_TRIM     0 /* 0:Disable or 1:Enable */
+/* To enable sector erase feature, set _USE_TRIM to 1. Also CTRL_ERASE_SECTOR command
+/  should be added to the disk_ioctl() function. */
+
+
+#define _FS_NOFSINFO    0 /* 0 or 1 */
+/* If you need to know the correct free space on the FAT32 volume, set this
+/  option to 1 and f_getfree() function at first time after volume mount will
+/  force a full FAT scan.
+/
+/  0: Load all informations in the FSINFO if available.
+/  1: Do not trust free cluster count in the FSINFO.
+*/
+
+
+/*---------------------------------------------------------------------------/
+/ System Configurations
+/----------------------------------------------------------------------------*/
+
+#define _WORD_ACCESS    0 /* 0 or 1 */
+/* The _WORD_ACCESS option is an only platform dependent option. It defines
+/  which access method is used to the word data on the FAT volume.
+/
+/   0: Byte-by-byte access. Always compatible with all platforms.
+/   1: Word access. Do not choose this unless under both the following conditions.
+/
+/  * Byte order on the memory is little-endian.
+/  * Address miss-aligned word access is always allowed for all instructions.
+/
+/  If it is the case, _WORD_ACCESS can also be set to 1 to improve performance
+/  and reduce code size.
+*/
+
+
+/* A header file that defines sync object types on the O/S, such as
+/  windows.h, ucos_ii.h and semphr.h, must be included prior to ff.h. */
+
+#define _FS_REENTRANT    0  /* 0:Disable or 1:Enable */
+#define _FS_TIMEOUT      1000 /* Timeout period in unit of time ticks */
+#define _SYNC_t          0 /* O/S dependent type of sync object. e.g. HANDLE, OS_EVENT*, ID and etc.. */
+
+/* The _FS_REENTRANT option switches the re-entrancy (thread safe) of the FatFs module.
+/
+/   0: Disable re-entrancy. _SYNC_t and _FS_TIMEOUT have no effect.
+/   1: Enable re-entrancy. Also user provided synchronization handlers,
+/      ff_req_grant(), ff_rel_grant(), ff_del_syncobj() and ff_cre_syncobj()
+/      function must be added to the project. */
+
+
+#define _FS_LOCK    0      /* 0:Disable or >=1:Enable */
+/* To enable file lock control feature, set _FS_LOCK to 1 or greater.
+   The value defines how many files can be opened simultaneously. */
+
+#define _FS_NORTC          0
+#define _NORTC_MON         2
+#define _NORTC_MDAY        1
+#define _NORTC_YEAR        2015
+/* The _FS_NORTC option switches timestamp feature. If the system does not have
+/� an RTC function or valid timestamp is not needed, set _FS_NORTC to 1 to disable
+/� the timestamp feature. All objects modified by FatFs will have a fixed timestamp
+/� defined by _NORTC_MON, _NORTC_MDAY and _NORTC_YEAR.
+/� When timestamp feature is enabled (_FS_NORTC == 0), get_fattime() function need
+/� to be added to the project to read current time form RTC. _NORTC_MON,
+/� _NORTC_MDAY and _NORTC_YEAR have no effect.
+/� These options have no effect at read-only configuration (_FS_READONLY == 1). */
+
+#if _NORTC_YEAR < 1980 || _NORTC_YEAR > 2107 || _NORTC_MON < 1 || _NORTC_MON > 12 || _NORTC_MDAY < 1 || _NORTC_MDAY > 31
+  #error Invalid _FS_NORTC settings
+#endif
+
+#endif /* _FFCONFIG */


### PR DESCRIPTION
* Fix some warnings raised during the build
* Add a default `ffconf.h` to avoid embed it in the core and allow easiest user configThe FatFs has several user defined options, which is specified from within the `ffconf.h` file.
This library provides a default user defined options file named `ffconf_default.h`.
User can provide his own defined options by adding his configuration in a file named `ffconf_custom.h` at sketch level or in variant folder.
* Fix SD detect pin usage:  SD detect pin was hardcoded in `sd_conf.h` while API  provide a way to specify it. This require to provide the pin number instead of the `GPIO_PIN_x` pin and `GPIOX port`.
That's why `sd_conf.h` usage has been removed.
Moreover several definition for the BSP are common or only dependent to SD instance.
SD instance could be `SDMMC1 `or `SDIO `depending of the STM32 series.
Only the SD detects definition should be redefined thanks the `variant.h` if the board has one.
* Unify `begin()` methods and `BSP_SD_*init()` functions: use methods with default parameters value.