### PR TITLE
File object structure (FIL) must be a pointer

### DIFF
--- a/examples/Full/Full.ino
+++ b/examples/Full/Full.ino
@@ -39,10 +39,18 @@ void setup()
   Serial.println("Creating 'ARDUINO/SD' directory");
   SD.mkdir("ARDUINO/SD");
 
+  /* Test bool operator method */
+  Serial.print("Test bool operator...");
+  if (!MyFile) {
+    Serial.println("OK");
+  } else {
+    Serial.println("Error MyFile should not be initialized!");
+  }
+
   /* Test open() method */
   Serial.println("Opening 'STM32/Toremove.txt' file");
   MyFile = SD.open("STM32/Toremove.txt", FILE_WRITE);
-  if(MyFile) {
+  if (MyFile) {
     Serial.println("Closing 'STM32/Toremove.txt' file");
     MyFile.close();
   } else {
@@ -50,7 +58,7 @@ void setup()
   }
   Serial.println("Opening 'ARDUINO/SD/ARDUINO_SD_TEXT.txt' file");
   MyFile = SD.open("ARDUINO/SD/ARDUINO_SD_TEXT.txt", FILE_WRITE);
-  if(MyFile) {
+  if (MyFile) {
     /* Test print() method */
     Serial.print("writing \"");
     Serial.print((const char*)wtext);
@@ -67,7 +75,7 @@ void setup()
 
   Serial.println("Opening 'ARDUINO/SD/ARDUINO_SD_TEXT.txt' file");
   MyFile = SD.open("ARDUINO/SD/ARDUINO_SD_TEXT.txt");
-  if(MyFile) {
+  if (MyFile) {
     bytesread = MyFile.read(rtext, MyFile.size());
     Serial.println("Closing 'ARDUINO/SD/ARDUINO_SD_TEXT.txt' file");
     MyFile.close();
@@ -77,7 +85,7 @@ void setup()
 
   Serial.println("Opening 'ARDUINO/SD/TEXT.txt' file");
   MyFile = SD.open("ARDUINO/SD/TEXT.txt", FILE_WRITE);
-  if(MyFile) {
+  if (MyFile) {
     byteswritten = MyFile.print((const char*)rtext);
     MyFile.flush();
     Serial.println("Closing 'ARDUINO/SD/TEXT.txt' file");
@@ -88,7 +96,7 @@ void setup()
 
   Serial.println("Opening 'ARDUINO/SD/TEXT.txt' file");
   MyFile = SD.open("ARDUINO/SD/TEXT.txt");
-  if(MyFile) {
+  if (MyFile) {
     /* Test size() method */
     file_size = MyFile.size();
     Serial.print("TEXT.txt size: ");
@@ -97,12 +105,12 @@ void setup()
     /* Test position and seek method */
     Serial.print("TEXT.txt position value: ");
     Serial.println(MyFile.position());
-    if(!MyFile.seek(MyFile.size()+1)) {
+    if (!MyFile.seek(MyFile.size() + 1)) {
       Serial.println("TEXT.txt seek value over size: OK");
     } else {
       Serial.println("TEXT.txt seek value over size: KO");
     }
-    if(MyFile.seek(MyFile.size())) {
+    if (MyFile.seek(MyFile.size())) {
       Serial.println("TEXT.txt seek value to size: OK");
     } else {
       Serial.println("TEXT.txt seek value to size: KO");
@@ -110,7 +118,7 @@ void setup()
     Serial.print("TEXT.txt position value: ");
     Serial.println(MyFile.position());
 
-    if(MyFile.seek(0)) {
+    if (MyFile.seek(0)) {
       Serial.println("TEXT.txt seek value to 0: OK");
     } else {
       Serial.println("TEXT.txt seek value to 0: KO");
@@ -120,7 +128,7 @@ void setup()
 
     /* Test peek() method */
     Serial.println("TEXT.txt peek (10 times): ");
-    for(i = 0; i<10; i++)
+    for (i = 0; i < 10; i++)
     {
       peek_val = MyFile.peek();
       Serial.print(peek_val);
@@ -132,7 +140,7 @@ void setup()
 
     /* Test available() and read() methods */
     Serial.println("TEXT.txt content read byte per byte: ");
-    while(MyFile.available())
+    while (MyFile.available())
     {
       rtext[i] = (uint8_t)MyFile.read();
       Serial.print(rtext[i]);
@@ -150,7 +158,7 @@ void setup()
 
   /* Test isDirectory() method */
   MyFile = File("STM32");
-  if(MyFile) {
+  if (MyFile) {
     Serial.print("Is 'STM32' is a dir: ");
     if (MyFile.isDirectory())
       Serial.println("OK");
@@ -162,7 +170,7 @@ void setup()
 
   Serial.println("Opening 'STM32/Toremove.txt' file");
   MyFile = SD.open("STM32/Toremove.txt");
-  if(MyFile) {
+  if (MyFile) {
     Serial.print("Is 'STM32/Toremove.txt' is a file: ");
     if (MyFile.isDirectory())
       Serial.println("KO");
@@ -175,23 +183,23 @@ void setup()
   }
   /* Test exists(), remove() and rmdir() methods */
   Serial.print("Removing 'STM32/Toremove.txt' file...");
-  while(SD.exists("STM32/Toremove.txt") == TRUE)
+  while (SD.exists("STM32/Toremove.txt") == TRUE)
   {
     SD.remove("STM32/Toremove.txt");
-   }
+  }
   Serial.println("done");
 
   Serial.print("Removing 'STM32' dir...");
-  while(SD.exists("STM32") == TRUE)
+  while (SD.exists("STM32") == TRUE)
   {
     SD.rmdir("STM32");
-   }
+  }
   Serial.println("done");
 
   /* Test println(), println(data) methods */
   Serial.println("Opening 'ARDUINO/SD/PRINT.txt' file");
   MyFile = SD.open("ARDUINO/SD/PRINT.txt", FILE_WRITE);
-  if(MyFile) {
+  if (MyFile) {
     String str = String("This is a String object on line 7");
     Serial.print("Printing to 'ARDUINO/SD/PRINT.txt' file...");
     MyFile.println("This should be line 1");
@@ -211,7 +219,7 @@ void setup()
   /* Test write(buf, len) method */
   Serial.println("Opening 'ARDUINO/SD/WRITE.txt' file");
   MyFile = SD.open("ARDUINO/SD/WRITE.txt", FILE_WRITE);
-  if(MyFile) {
+  if (MyFile) {
     Serial.print("Writing 'ARDUINO/SD/WRITE.txt' file: ");
     byteswritten = MyFile.write(wtext, BUFFERSIZE);
     Serial.print(byteswritten);
@@ -225,13 +233,13 @@ void setup()
   /* Test read(buf, len) method */
   Serial.println("Opening 'ARDUINO/SD/WRITE.txt' file");
   MyFile = SD.open("ARDUINO/SD/WRITE.txt");
-  if(MyFile) {
+  if (MyFile) {
     Serial.println("Reading 'ARDUINO/SD/WRITE.txt' file:");
     bytesread = MyFile.read(rtext, MyFile.size());
     Serial.println((const char*)rtext);
     Serial.println("Closing 'ARDUINO/SD/WRITE.txt' file");
     MyFile.close();
-   } else {
+  } else {
     Serial.println("Error to open 'ARDUINO/SD/WRITE.txt' file");
   }
   Serial.println("###### End of the SD tests ######");
@@ -239,5 +247,5 @@ void setup()
 
 void loop()
 {
- // do nothing
+  // do nothing
 }

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -134,7 +134,7 @@ File SDClass::open(const char *filepath)
 {
     File file = File(filepath);
 
-    if(f_open(&file._fil, filepath, FA_READ) != FR_OK)
+    if(f_open(file._fil, filepath, FA_READ) != FR_OK)
     {
 		f_opendir(&file._dir, filepath);
 	}
@@ -156,7 +156,7 @@ File SDClass::open(const char *filepath, uint8_t mode)
         mode = mode | FA_CREATE_ALWAYS;
     }
 
-    if(f_open(&file._fil, filepath, mode) != FR_OK)
+    if(f_open(file._fil, filepath, mode) != FR_OK)
     {
 		f_opendir(&file._dir, filepath);
 	}
@@ -194,8 +194,10 @@ File SDClass::openRoot(void)
 File::File()
 {
 	_name = NULL;
-	 _fil.fs = 0;
-	 _dir.fs = 0;
+	_fil = (FIL*)malloc(sizeof(FIL));
+	assert(_fil != NULL );
+	_fil->fs = 0;
+	_dir.fs = 0;
 }
 
 File::File(const char* name)
@@ -203,7 +205,9 @@ File::File(const char* name)
 	_name = (char*)malloc(strlen(name) +1);
 	assert(_name  != NULL );
 	sprintf(_name, "%s", name);
-	_fil.fs = 0;
+    _fil = (FIL*)malloc(sizeof(FIL));
+	assert(_fil != NULL );
+	_fil->fs = 0;
 	_dir.fs = 0;
 }
 
@@ -345,7 +349,7 @@ int File::read()
 {
     uint8_t byteread;
     int8_t data;
-    f_read(&_fil, (void *)&data, 1, (UINT *)&byteread);
+    f_read(_fil, (void *)&data, 1, (UINT *)&byteread);
     return data;
 }
 
@@ -359,7 +363,7 @@ int File::read(void* buf, size_t len)
 {
     uint8_t bytesread;
 
-    f_read(&_fil, buf, len, (UINT *)&bytesread);
+    f_read(_fil, buf, len, (UINT *)&bytesread);
     return bytesread;
 
 }
@@ -373,12 +377,13 @@ void File::close()
 {
 	if(_name)
 	{
-		if(_fil.fs != 0) {
+		if(_fil && _fil->fs != 0) {
 			/* Flush the file before close */
-			f_sync(&_fil);
+			f_sync(_fil);
 
 			/* Close the file */
-			f_close(&_fil);
+			f_close(_fil);
+            free(_fil);
 		}
 
 		if(_dir.fs != 0) {
@@ -397,7 +402,7 @@ void File::close()
   */
 void File::flush()
 {
-    f_sync(&_fil);
+    f_sync(_fil);
 }
 
 /**
@@ -421,7 +426,7 @@ int File::peek()
 uint32_t File::position()
 {
     uint32_t filepos = 0;
-    filepos = f_tell(&_fil);
+    filepos = f_tell(_fil);
     return filepos;
 }
 
@@ -438,7 +443,7 @@ uint8_t File::seek(uint32_t pos)
   }
   else
   {
-    if(f_lseek(&_fil, pos) != FR_OK)
+    if(f_lseek(_fil, pos) != FR_OK)
     {
       return FALSE;
     }
@@ -458,12 +463,12 @@ uint32_t File::size()
 {
     uint32_t file_size = 0;
 
-    file_size = f_size(&_fil);
+    file_size = f_size(_fil);
     return(file_size);
 }
 
 File::operator bool() {
-  return  ((_name == NULL) || ((_fil.fs == 0) && (_dir.fs == 0))) ? FALSE : TRUE;
+  return  ((_name == NULL) || ((_fil == NULL) && (_dir.fs == 0)) || ((_fil != NULL) && (_fil->fs == 0) && (_dir.fs == 0))) ? FALSE : TRUE;
 }
 /**
   * @brief  Write data to the file
@@ -484,7 +489,7 @@ size_t File::write(uint8_t data)
 size_t File::write(const char *buf, size_t size)
 {
     size_t byteswritten;
-    f_write(&_fil, (const void *)buf, size, (UINT *)&byteswritten);
+    f_write(_fil, (const void *)buf, size, (UINT *)&byteswritten);
     return byteswritten;
 }
 
@@ -563,7 +568,7 @@ uint8_t File::isDirectory()
 	assert(_name  != NULL );
 	if (_dir.fs != 0)
 		return TRUE;
-	else if (_fil.fs != 0)
+	else if (_fil->fs != 0)
 		return FALSE;
 	// if not init get info
 	if (f_stat(_name, &fno) == FR_OK)

--- a/src/STM32SD.h
+++ b/src/STM32SD.h
@@ -68,7 +68,7 @@ public:
 
 
   char *_name = NULL; //file or dir name
-  FIL _fil = {}; // init all fields to 0
+  FIL* _fil = NULL; // underlying file object structure pointer
   DIR _dir = {}; // init all fields to 0
 
 };


### PR DESCRIPTION
Using the TFT library TFTBitmapLogo example, SD file opened is
passed to read function. If FIL is not a pointer (as it is copied thanks
the copy constructor), file read/write pointer (fptr) is never
incremented so always reading from beginning of the file.

Fix #1

