### PR TITLE
Fix RAM losses when creating files

### DIFF
--- a/src/STM32SD.h
+++ b/src/STM32SD.h
@@ -33,7 +33,6 @@ uint8_t const LS_R = 4;
 class File {
   public:
     File(void);
-    File(const char *name);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *buf, size_t size);
     virtual size_t write(const char *buf, size_t size);
@@ -82,8 +81,7 @@ class SDClass {
 
     /* Initialize the SD peripheral */
     bool begin(uint32_t detectpin = SD_DETECT_NONE);
-    static File open(const char *filepath, uint8_t mode);
-    static File open(const char *filepath);
+    static File open(const char *filepath, uint8_t mode = FA_READ);
     static bool exists(const char *filepath);
     static bool mkdir(const char *filepath);
     static bool remove(const char *filepath);


### PR DESCRIPTION
File::File used to allocate RAM what was not freed when destroying the File object.
Adding a dedicated destructor war not enough to fix. It would also need copy- and move-constructors.

Instead of that i went an other way.

Removed the `File::FILE(const char* name)` constructor.
Changed the `File::File(void)` constructor to not `malloc()` any RAM.

Unified and changed the SDClass::open() methods.
Removed the open method without mode parameter. Instead gave a default mode to the method with a mode parameter.
Now open() has the complete control over memory allocation. When it is not able to open a file no memory in left allocated. 

Advantage: 
A created File that was not opened or was not able to be opened has not to be closed anymore to avoid memory losses. Only a successfully opened file has to be closed.

Fixing the memory leak, not only working around #24: 