### PR TITLE
feat: support transceiver for H7, L5 and U5

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Some default definitions can be overridden using:
 
 #### SD Transceiver
 
-* `SD_TRANSCEIVER_MODE`: specifies whether external Transceiver is enabled or disabled. Available only on some STM32
-  * `SDMMC_TRANSCEIVER_ENABLE`
-  * `SDMMC_TRANSCEIVER_DISABLE` (default)
+* To specifies whether external Transceiver is present and enabled (Available only on some STM32) add:
 
-* `SD_TRANSCEIVER_EN` pin number to enable the level shifter
-* `SD_TRANSCEIVER_SEL` pin number for voltage selection
+  `#define USE_SD_TRANSCEIVER  1`
+* Then define pins:
+  * `SD_TRANSCEIVER_EN` pin number to enable the level shifter
+  * `SD_TRANSCEIVER_SEL` pin number for voltage selection
 
 #### SD detect and timeout
 * `SD_DETECT_PIN` pin number

--- a/src/Sd2Card.cpp
+++ b/src/Sd2Card.cpp
@@ -47,13 +47,15 @@ bool Sd2Card::init(uint32_t detectpin)
       return false;
     }
   }
-#ifdef SDMMC_TRANSCEIVER_ENABLE
+#if defined(USE_SD_TRANSCEIVER) && (USE_SD_TRANSCEIVER != 0U)
   PinName sd_en = digitalPinToPinName(SD_TRANSCEIVER_EN);
   PinName sd_sel = digitalPinToPinName(SD_TRANSCEIVER_SEL);
-  BSP_SD_TransceiverPin(set_GPIO_Port_Clock(STM_PORT(sd_en)),
-                        STM_LL_GPIO_PIN(sd_en),
-                        set_GPIO_Port_Clock(STM_PORT(sd_sel)),
-                        STM_LL_GPIO_PIN(sd_sel));
+  if (BSP_SD_TransceiverPin(set_GPIO_Port_Clock(STM_PORT(sd_en)),
+                            STM_LL_GPIO_PIN(sd_en),
+                            set_GPIO_Port_Clock(STM_PORT(sd_sel)),
+                            STM_LL_GPIO_PIN(sd_sel)) == MSD_ERROR) {
+    return false;
+  }
 #endif
   if (BSP_SD_Init() == MSD_OK) {
     BSP_SD_GetCardInfo(&_SdCardInfo);

--- a/src/bsp_sd.h
+++ b/src/bsp_sd.h
@@ -53,6 +53,11 @@ extern "C" {
 Please update the core or install previous library version."
 #endif
 
+/* For backward compatibility */
+#if defined(SD_TRANSCEIVER_MODE) && !defined(USE_SD_TRANSCEIVER)
+#define USE_SD_TRANSCEIVER        1
+#endif
+
 /*SD Card information structure */
 #ifndef STM32L1xx
 #define HAL_SD_CardInfoTypedef         HAL_SD_CardInfoTypeDef
@@ -72,22 +77,19 @@ Please update the core or install previous library version."
 #define SD_PRESENT               ((uint8_t)0x01)
 #define SD_NOT_PRESENT           ((uint8_t)0x00)
 #define SD_DETECT_NONE           NUM_DIGITAL_PINS
-#ifdef SDMMC_TRANSCEIVER_ENABLE
-#define SD_TRANSCEIVER_NONE      NUM_DIGITAL_PINS
-#endif
 
 /* Could be redefined in variant.h or using build_opt.h */
 #ifndef SD_DATATIMEOUT
 #define SD_DATATIMEOUT         100000000U
 #endif
 
-#ifdef SDMMC_TRANSCEIVER_ENABLE
+#if defined(USE_SD_TRANSCEIVER) && (USE_SD_TRANSCEIVER != 0U)
 #ifndef SD_TRANSCEIVER_EN
-#define SD_TRANSCEIVER_EN      SD_TRANSCEIVER_NONE
+#define SD_TRANSCEIVER_EN        NUM_DIGITAL_PINS
 #endif
 
 #ifndef SD_TRANSCEIVER_SEL
-#define SD_TRANSCEIVER_SEL     SD_TRANSCEIVER_NONE
+#define SD_TRANSCEIVER_SEL       NUM_DIGITAL_PINS
 #endif
 #endif
 
@@ -98,7 +100,7 @@ Please update the core or install previous library version."
 /* SD Exported Functions */
 uint8_t BSP_SD_Init(void);
 uint8_t BSP_SD_DeInit(void);
-#ifdef SDMMC_TRANSCEIVER_ENABLE
+#if defined(USE_SD_TRANSCEIVER) && (USE_SD_TRANSCEIVER != 0U)
 uint8_t BSP_SD_TransceiverPin(GPIO_TypeDef *enport, uint32_t enpin, GPIO_TypeDef *selport, uint32_t selpin);
 #endif
 uint8_t BSP_SD_DetectPin(GPIO_TypeDef *port, uint32_t pin);
@@ -124,7 +126,7 @@ uint8_t BSP_SD_IsDetected(void);
 void    BSP_SD_MspInit(SD_HandleTypeDef *hsd, void *Params);
 void    BSP_SD_Detect_MspInit(SD_HandleTypeDef *hsd, void *Params);
 void    BSP_SD_MspDeInit(SD_HandleTypeDef *hsd, void *Params);
-#ifdef SDMMC_TRANSCEIVER_ENABLE
+#if defined(USE_SD_TRANSCEIVER) && (USE_SD_TRANSCEIVER != 0U)
 void    BSP_SD_Transceiver_MspInit(SD_HandleTypeDef *hsd, void *Params);
 #endif
 


### PR DESCRIPTION
* To specifies whether external Transceiver is present and enabled (Available only on some STM32) add:

  `#define USE_SD_TRANSCEIVER  1`
* Then define pins:
  * `SD_TRANSCEIVER_EN` pin number to enable the level shifter
  * `SD_TRANSCEIVER_SEL` pin number for voltage selection