### PR TITLE
File inherits from Stream: proper support for print and println of al…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+.vscode

--- a/examples/Full/Full.ino
+++ b/examples/Full/Full.ino
@@ -251,6 +251,8 @@ void setup()
     MyFile.println();
     MyFile.println("This should be line 6");
     MyFile.println(str);
+    MyFile.print("This should be line ");
+    MyFile.println(8);
     Serial.println("OK");
     Serial.print("Closing 'ARDUINO/SD/PRINT.txt' file");
     Serial.println("OK");
@@ -291,7 +293,26 @@ void setup()
   } else {
     Serial.println("KO --> Error to open 'ARDUINO/SD/WRITE.txt' file");
   }
+
+  /* Test readBytes(buf, len) method */
+  Serial.print("Opening 'ARDUINO/SD/WRITE.txt' file...");
+  MyFile = SD.open("ARDUINO/SD/WRITE.txt");
+  if (MyFile) {
+    Serial.println("OK");
+    Serial.print("  Reading 'ARDUINO/SD/WRITE.txt' file: ");
+    bytesread = MyFile.readBytes(rtext, MyFile.size());
+    Serial.print(bytesread);
+    Serial.println(" bytes read");
+    Serial.println((const char*)rtext);
+    Serial.print("Closing 'ARDUINO/SD/WRITE.txt' file...");
+    MyFile.close();
+    Serial.println("OK");
+  } else {
+    Serial.println("KO --> Error to open 'ARDUINO/SD/WRITE.txt' file");
+  }
   Serial.println("###### End of the SD tests ######");
+
+
 }
 
 void loop()

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -548,47 +548,6 @@ size_t File::write(const uint8_t *buf, size_t size)
 }
 
 /**
-  * @brief  Print data to the file
-  * @param  data: Data to write to the file
-  * @retval Number of data written (1)
-  */
-size_t File::print(const char *data)
-{
-  return write(data, strlen(data));
-}
-
-/**
-  * @brief  Print data to the file
-  * @retval Number of data written (1)
-  */
-size_t File::println()
-{
-  return write("\r\n", 2);
-}
-
-/**
-  * @brief  Print data to the file
-  * @param  data: Data to write to the file
-  * @retval Number of data written (1)
-  */
-size_t File::println(const char *data)
-{
-  size_t bytewritten = write(data, strlen(data));
-  bytewritten += println();
-  return bytewritten;
-}
-
-/**
-  * @brief  Print data to the file
-  * @param  data: Data of type String to write to the file
-  * @retval Number of data written (1)
-  */
-size_t File::println(String &data)
-{
-  return println(data.c_str());
-}
-
-/**
   * @brief  Check if there are any bytes available for reading from the file
   * @retval Number of bytes available
   */

--- a/src/STM32SD.h
+++ b/src/STM32SD.h
@@ -30,7 +30,7 @@ uint8_t const LS_SIZE = 2;
 /** ls() flag for recursive list of subdirectories */
 uint8_t const LS_R = 4;
 
-class File {
+class File : public Stream {
   public:
     File(FRESULT res = FR_OK);
     virtual size_t write(uint8_t);
@@ -57,11 +57,6 @@ class File {
     File openNextFile(uint8_t mode = FILE_READ);
     void rewindDirectory(void);
 
-    virtual size_t print(const char *data);
-    virtual size_t println();
-    virtual size_t println(const char *data);
-    virtual size_t println(String &data);
-
     // Print to Serial line
     void ls(uint8_t flags, uint8_t indent = 0);
     static void printFatDate(uint16_t fatDate);
@@ -78,6 +73,8 @@ class File {
     {
       return _res;
     }
+    using Print::println;
+    using Print::print;
 
 };
 


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

File must inherit from Stream: proper support for print and println of all supported data types.
The motivation for this, was that in all other SD libraries the File impelmentation is a subclass of Stream which itself is a subclass of Print.

With this change we can now also provide the files of this library to any Arduino function which expects a Stream or a Print.

**Validation**

I extended the test sketch Full.ino to test the readBytes() method and the printing of an integer.


**Closing issues**

I did not file any issue but decided to submit a pull request directly to speed up things.
see https://github.com/orgs/stm32duino/discussions/2428