### PR TITLE
fix: properly set SD pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Some default definitions can be overridden using:
 
 #### SDIO/SDMMC pins definition
 
-Since STM32 core v2.6.0, the `PinMap_SD[]` array defined in the `PeripheralPins*.c` has been split per signals:
+> [!IMPORTANT]
+> Since STM32 core v2.6.0, the `PinMap_SD[]` array defined in the `PeripheralPins*.c` has been split per signals:
+
 ```C
 PinMap_SD_CK[]
 PinMap_SD_DATA0[]
@@ -74,9 +76,11 @@ By default, if no pins are explicitly defined, the first one from each array is 
     * `SDX_D0DIR`
     * `SDX_D123DIR`
 
-* or redefine the default one before call of `begin()` of `SDClass` or `init()` of `Sd2Card`, use the following methods:
+* or redefine the default one before call of `begin()` of `SDClass` or `init()` of `Sd2Card`, using the following methods:
 
   * `setDx(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3)`
+  > [!NOTE]
+  > If `SD_BUS_WIDE_1B` is used only `data0` is needed.
   * `setCK(uint32_t ck)`
   * `setCK(PinName ck)`
   * `setCMD(uint32_t cmd)`
@@ -104,31 +108,6 @@ By default, if no pins are explicitly defined, the first one from each array is 
   SD.setCMD(PB14);
   SD.setCK(PB_15); // using PinName
   SD.begin();
-```
-
-* or using the `begin()` of `SDClass` or `init()` of `Sd2Card` methods:
-
-  * For `SDIO`:
-    * `SDClass`:
-      * `begin(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t ck, uint32_t cmd)`
-      * `begin(uint32_t detect = SD_DETECT_NONE, uint32_t data0 = SDX_D0, uint32_t data1 = SDX_D1, uint32_t data2 = SDX_D2, uint32_t data3 = SDX_D3, uint32_t ck = SDX_CK, uint32_t cmd = SDX_CMD, uint32_t ckin = SDX_CKIN, uint32_t cdir = SDX_CDIR, uint32_t d0dir = SDX_D0DIR, uint32_t d123dir = SDX_D123DIR);`
-    * `Sd2Card`:
-      * `init(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t ck, uint32_t cmd)`
-      * `init(uint32_t detect = SD_DETECT_NONE, uint32_t data0 = SDX_D0, uint32_t data1 = SDX_D1, uint32_t data2 = SDX_D2, uint32_t data3 = SDX_D3, uint32_t ck = SDX_CK, uint32_t cmd = SDX_CMD);`
-
-  * For `SDMMC`:
-    * `SDClass`:
-      * `begin(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t ck, uint32_t cmd, uint32_t ckin,  uint32_t cdir, uint32_t d0dir, uint32_t d123dir);`
-      * `begin(uint32_t detect = SD_DETECT_NONE, uint32_t data0 = SDX_D0, uint32_t data1 = SDX_D1, uint32_t data2 = SDX_D2, uint32_t data3 = SDX_D3, uint32_t ck = SDX_CK, uint32_t cmd = SDX_CMD, uint32_t ckin = SDX_CKIN, uint32_t cdir = SDX_CDIR, uint32_t d0dir = SDX_D0DIR, uint32_t d123dir = SDX_D123DIR);`
-      *
-    * * `Sd2Card`:
-      * `init(uint32_t data0 = SDX_D0, uint32_t data1 = SDX_D1, uint32_t data2 = SDX_D2, uint32_t data3 = SDX_D3, uint32_t ck = SDX_CK, uint32_t cmd = SDX_CMD, uint32_t ckin = SDX_CKIN, uint32_t cdir = SDX_CDIR, uint32_t d0dir = SDX_D0DIR, uint32_t d123dir = SDX_D123DIR)`
-      * `init(uint32_t detect = SD_DETECT_NONE, uint32_t data0 = SDX_D0, uint32_t data1 = SDX_D1, uint32_t data2 = SDX_D2, uint32_t data3 = SDX_D3, uint32_t ck = SDX_CK, uint32_t cmd = SDX_CMD, uint32_t ckin = SDX_CKIN, uint32_t cdir = SDX_CDIR, uint32_t d0dir = SDX_D0DIR, uint32_t d123dir = SDX_D123DIR);`
-
-  *Code snippet:*
-```C++
-  card.init(PE12, PE13, PE14, PE15, PB14, PB15);
-  SD.begin(SD_DETECT_PIN, PE12, PE13, PE14, PE15, PB14, PB15);
 ```
 
 #### SD configurations

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -59,66 +59,11 @@ SDClass SD;
 /**
   * @brief  Link SD, register the file system object to the FatFs mode and configure
   *         relatives SD IOs including SD Detect Pin if any
-  * @param  data0: data0 pin number (default SDX_D0)
-  * @param  data1: data1 pin number (default SDX_D1)
-  * @param  data2: data2 pin number (default SDX_D2)
-  * @param  data3: data3 pin number (default SDX_D3)
-  * @param  ck: ck pin number (default SDX_CK)
-  * @param  cmd: cmd pin number (default SDX_CMD)
-  * @param  ckin: ckin pin number only for SDMMC (default SDX_CKIN)
-  * @param  cdir: cdir pin number only for SDMMC (default SDX_CDIR)
-  * @param  d0dir: d0dir pin number only for SDMMC (default SDX_D0DIR)
-  * @param  d123dir: d123dir pin number only for SDMMC (default SDX_D123DIR)
-  * @retval true or false
-  */
-#if defined(SDMMC1) || defined(SDMMC2)
-bool SDClass::begin(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3,
-                    uint32_t ck, uint32_t cmd, uint32_t ckin, uint32_t cdir,
-                    uint32_t d0dir, uint32_t d123dir)
-{
-  return begin(SD_DETECT_NONE, data0, data1, data2, data3, ck, cmd, ckin, cdir, d0dir, d123dir);
-}
-
-#else
-bool SDClass::begin(uint32_t data0, uint32_t data1, uint32_t data2,
-                    uint32_t data3, uint32_t ck, uint32_t cmd)
-{
-  return begin(SD_DETECT_NONE, data0, data1, data2, data3, ck, cmd);
-}
-#endif
-
-/**
-  * @brief  Link SD, register the file system object to the FatFs mode and configure
-  *         relatives SD IOs including SD Detect Pin if any
   * @param  detect: detect pin number (default SD_DETECT_NONE)
-  * @param  data0: data0 pin number (default SDX_D0)
-  * @param  data1: data1 pin number (default SDX_D1)
-  * @param  data2: data2 pin number (default SDX_D2)
-  * @param  data3: data3 pin number (default SDX_D3)
-  * @param  ck: ck pin number (default SDX_CK)
-  * @param  cmd: cmd pin number (default SDX_CMD)
-  * @param  ckin: ckin pin number only for SDMMC (default SDX_CKIN)
-  * @param  cdir: cdir pin number only for SDMMC (default SDX_CDIR)
-  * @param  d0dir: d0dir pin number only for SDMMC (default SDX_D0DIR)
-  * @param  d123dir: d123dir pin number only for SDMMC (default SDX_D123DIR)
   * @retval true or false
   */
-#if defined(SDMMC1) || defined(SDMMC2)
-bool SDClass::begin(uint32_t detect, uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3,
-                    uint32_t ck, uint32_t cmd, uint32_t ckin, uint32_t cdir, uint32_t d0dir, uint32_t d123dir)
-#else
-bool SDClass::begin(uint32_t detect, uint32_t data0, uint32_t data1, uint32_t data2,
-                    uint32_t data3, uint32_t ck, uint32_t cmd)
-#endif
+bool SDClass::begin(uint32_t detect)
 {
-  setDx(data0, data1, data2, data3);
-  setCK(ck);
-  setCMD(cmd);
-#if defined(SDMMC1) || defined(SDMMC2)
-  setCKIN(ckin);
-  setCDIR(cdir);
-  setDxDIR(d0dir, d123dir);
-#endif
   /*##-1- Initializes SD IOs #############################################*/
   if (_card.init(detect)) {
     return _fatFs.init();

--- a/src/STM32SD.h
+++ b/src/STM32SD.h
@@ -86,23 +86,10 @@ class SDClass {
 
   public:
     /* Initialize the SD peripheral */
-#if defined(SDMMC1) || defined(SDMMC2)
-    bool begin(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t ck, uint32_t cmd,
-               uint32_t ckin,  uint32_t cdir, uint32_t d0dir, uint32_t d123dir
-              );
-    bool begin(uint32_t detect = SD_DETECT_NONE, uint32_t data0 = SDX_D0, uint32_t data1 = SDX_D1,
-               uint32_t data2 = SDX_D2, uint32_t data3 = SDX_D3, uint32_t ck = SDX_CK, uint32_t cmd = SDX_CMD,
-               uint32_t ckin = SDX_CKIN, uint32_t cdir = SDX_CDIR, uint32_t d0dir = SDX_D0DIR, uint32_t d123dir = SDX_D123DIR
-              );
-#else
-    bool begin(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t ck, uint32_t cmd);
-    bool begin(uint32_t detect = SD_DETECT_NONE, uint32_t data0 = SDX_D0, uint32_t data1 = SDX_D1,
-               uint32_t data2 = SDX_D2, uint32_t data3 = SDX_D3, uint32_t ck = SDX_CMD, uint32_t cmd = SDX_CMD
-              );
-#endif
+    bool begin(uint32_t detect = SD_DETECT_NONE);
 
     // set* have to be called before begin()
-    void setDx(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3)
+    void setDx(uint32_t data0, uint32_t data1 = PNUM_NOT_DEFINED, uint32_t data2 = PNUM_NOT_DEFINED, uint32_t data3 = PNUM_NOT_DEFINED)
     {
       _card.setDx(data0, data1, data2, data3);
     };
@@ -115,7 +102,7 @@ class SDClass {
       _card.setCMD(cmd);
     };
 
-    void setDx(PinName data0, PinName data1, PinName data2, PinName data3)
+    void setDx(PinName data0, PinName data1 = NC, PinName data2 = NC, PinName data3 = NC)
     {
       _card.setDx(data0, data1, data2, data3);
     };

--- a/src/Sd2Card.cpp
+++ b/src/Sd2Card.cpp
@@ -37,35 +37,23 @@
 #include <Arduino.h>
 #include "Sd2Card.h"
 
+/**
+  * @brief  Default constructor. Use default pins definition.
+  */
+Sd2Card::Sd2Card()
+{
+  setDx(SDX_D0, SDX_D1, SDX_D2, SDX_D3);
+  setCK(SDX_CK);
+  setCMD(SDX_CMD);
 #if defined(SDMMC1) || defined(SDMMC2)
-bool Sd2Card::init(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t ck, uint32_t cmd,
-                   uint32_t ckin, uint32_t cdir, uint32_t d0dir, uint32_t d123dir)
-{
-  return init(SD_DETECT_NONE, data0, data1, data2, data3, ck, cmd, ckin, cdir, d0dir, d123dir);
-}
-#else
-bool Sd2Card::init(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t ck, uint32_t cmd)
-{
-  return init(SD_DETECT_NONE, data0, data1, data2, data3, ck, cmd);
-}
+  setCKIN(SDX_CKIN);
+  setCDIR(SDX_CDIR);
+  setDxDIR(SDX_D0DIR, SDX_D123DIR);
 #endif
+}
 
-#if defined(SDMMC1) || defined(SDMMC2)
-bool Sd2Card::init(uint32_t detect, uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3,
-                   uint32_t ck, uint32_t cmd, uint32_t ckin, uint32_t cdir, uint32_t d0dir, uint32_t d123dir)
-#else
-bool Sd2Card::init(uint32_t detect, uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3,
-                   uint32_t ck, uint32_t cmd)
-#endif
+bool Sd2Card::init(uint32_t detect)
 {
-  setDx(data0, data1, data2, data3);
-  setCK(ck);
-  setCMD(cmd);
-#if defined(SDMMC1) || defined(SDMMC2)
-  setCKIN(ckin);
-  setCDIR(cdir);
-  setDxDIR(d0dir, d123dir);
-#endif
   if (detect != SD_DETECT_NONE) {
     PinName p = digitalPinToPinName(detect);
     if ((p == NC) || \

--- a/src/Sd2Card.h
+++ b/src/Sd2Card.h
@@ -52,23 +52,12 @@
 
 class Sd2Card {
   public:
-#if defined(SDMMC1) || defined(SDMMC2)
-    bool init(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t ck, uint32_t cmd,
-              uint32_t ckin, uint32_t cdir, uint32_t d0dir, uint32_t d123dir
-             );
-    bool init(uint32_t detect = SD_DETECT_NONE, uint32_t data0 = SDX_D0, uint32_t data1 = SDX_D1,
-              uint32_t data2 = SDX_D2, uint32_t data3 = SDX_D3, uint32_t ck = SDX_CK, uint32_t cmd = SDX_CMD,
-              uint32_t ckin = SDX_CKIN, uint32_t cdir = SDX_CDIR, uint32_t d0dir = SDX_D0DIR, uint32_t d123dir = SDX_D123DIR
-             );
-#else
-    bool init(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t ck, uint32_t cmd);
-    bool init(uint32_t detect = SD_DETECT_NONE, uint32_t data0 = SDX_D0, uint32_t data1 = SDX_D1,
-              uint32_t data2 = SDX_D2, uint32_t data3 = SDX_D3, uint32_t ck = SDX_CK, uint32_t cmd = SDX_CMD
-             );
-#endif
+    Sd2Card();
+
+    bool init(uint32_t detect = SD_DETECT_NONE);
 
     // set* have to be called before init()
-    void setDx(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3)
+    void setDx(uint32_t data0, uint32_t data1 = PNUM_NOT_DEFINED, uint32_t data2 = PNUM_NOT_DEFINED, uint32_t data3 = PNUM_NOT_DEFINED)
     {
       SD_PinNames.pin_d0 = digitalPinToPinName(data0);
       SD_PinNames.pin_d1 = digitalPinToPinName(data1);
@@ -84,7 +73,7 @@ class Sd2Card {
       SD_PinNames.pin_cmd = digitalPinToPinName(cmd);
     };
 
-    void setDx(PinName data0, PinName data1, PinName data2, PinName data3)
+    void setDx(PinName data0, PinName data1 = NC, PinName data2 = NC, PinName data3 = NC)
     {
       SD_PinNames.pin_d0 = data0;
       SD_PinNames.pin_d1 = data1;

--- a/src/bsp_sd.c
+++ b/src/bsp_sd.c
@@ -145,31 +145,44 @@ uint8_t BSP_SD_GetInstance(void)
   SD_TypeDef *sd_cmd = NP;
   SD_TypeDef *sd_ck = NP;
 
+  /* If a pin is not defined, use the first pin available in the associated PinMap_SD_* arrays */
   if (SD_PinNames.pin_d0 == NC) {
-    /* No pin defined assume to use first pin available in each PinMap_SD_* arrays */
     SD_PinNames.pin_d0 = PinMap_SD_DATA0[0].pin;
 #if SD_BUS_WIDE == SD_BUS_WIDE_4B
     SD_PinNames.pin_d1 = PinMap_SD_DATA1[0].pin;
     SD_PinNames.pin_d2 = PinMap_SD_DATA2[0].pin;
     SD_PinNames.pin_d3 = PinMap_SD_DATA3[0].pin;
 #endif
+  }
+  if (SD_PinNames.pin_cmd == NC) {
     SD_PinNames.pin_cmd = PinMap_SD_CMD[0].pin;
+  }
+  if (SD_PinNames.pin_ck == NC) {
     SD_PinNames.pin_ck = PinMap_SD_CK[0].pin;
+  }
 #if defined(SDMMC1) || defined(SDMMC2)
 #if !defined(SDMMC_CKIN_NA)
+  if (SD_PinNames.pin_ckin == NC) {
     SD_PinNames.pin_ckin = PinMap_SD_CKIN[0].pin;
+  }
 #endif
 #if !defined(SDMMC_CDIR_NA)
+  if (SD_PinNames.pin_cdir == NC) {
     SD_PinNames.pin_cdir = PinMap_SD_CDIR[0].pin;
+  }
 #endif
 #if !defined(SDMMC_D0DIR_NA)
+  if (SD_PinNames.pin_d0dir == NC) {
     SD_PinNames.pin_d0dir = PinMap_SD_D0DIR[0].pin;
+  }
 #endif
 #if !defined(SDMMC_D123DIR_NA)
+  if (SD_PinNames.pin_d123dir == NC) {
     SD_PinNames.pin_d123dir = PinMap_SD_D123DIR[0].pin;
+  }
 #endif
 #endif /* SDMMC1 || SDMMC2 */
-  }
+
   /* Get SD instance from pins */
   sd_d0 = pinmap_peripheral(SD_PinNames.pin_d0, PinMap_SD_DATA0);
 #if SD_BUS_WIDE == SD_BUS_WIDE_4B

--- a/src/bsp_sd.h
+++ b/src/bsp_sd.h
@@ -115,35 +115,35 @@ Please update the core or install previous library version."
 
 /* Default SDx pins definitions */
 #ifndef SDX_D0
-#define SDX_D0           NUM_DIGITAL_PINS
+#define SDX_D0           PNUM_NOT_DEFINED
 #endif
 #ifndef SDX_D1
-#define SDX_D1           NUM_DIGITAL_PINS
+#define SDX_D1           PNUM_NOT_DEFINED
 #endif
 #ifndef SDX_D2
-#define SDX_D2           NUM_DIGITAL_PINS
+#define SDX_D2           PNUM_NOT_DEFINED
 #endif
 #ifndef SDX_D3
-#define SDX_D3           NUM_DIGITAL_PINS
+#define SDX_D3           PNUM_NOT_DEFINED
 #endif
 #ifndef SDX_CMD
-#define SDX_CMD          NUM_DIGITAL_PINS
+#define SDX_CMD          PNUM_NOT_DEFINED
 #endif
 #ifndef SDX_CK
-#define SDX_CK           NUM_DIGITAL_PINS
+#define SDX_CK           PNUM_NOT_DEFINED
 #endif
 #if defined(SDMMC1) || defined(SDMMC2)
 #ifndef SDX_CKIN
-#define SDX_CKIN         NUM_DIGITAL_PINS
+#define SDX_CKIN         PNUM_NOT_DEFINED
 #endif
 #ifndef SDX_CDIR
-#define SDX_CDIR         NUM_DIGITAL_PINS
+#define SDX_CDIR         PNUM_NOT_DEFINED
 #endif
 #ifndef SDX_D0DIR
-#define SDX_D0DIR        NUM_DIGITAL_PINS
+#define SDX_D0DIR        PNUM_NOT_DEFINED
 #endif
 #ifndef SDX_D123DIR
-#define SDX_D123DIR      NUM_DIGITAL_PINS
+#define SDX_D123DIR      PNUM_NOT_DEFINED
 #endif
 #endif /* SDMMC1 || SDMMC2 */
 


### PR DESCRIPTION
Only `set*()` methods and `SDx_*` definitions allows to manage the pins else the first pin available in the associated `PinMap_SD_*` arrays will be used.

Fixes #75.

With this reworks, begin and init are more simple and get back to previous prototype. Moreover it take in account of the SD BUS WIDE value.



